### PR TITLE
Add file processing utility

### DIFF
--- a/backend/test_file_processing.py
+++ b/backend/test_file_processing.py
@@ -1,0 +1,25 @@
+import pytest
+from pathlib import Path
+
+from utils.file_processing import process_uploaded_files
+
+
+def test_process_uploaded_files(tmp_path):
+    # Use existing sample files in uploads directory
+    uploads_dir = Path(__file__).resolve().parent / "uploads"
+    resume_pdf = uploads_dir / "JayResumeDraft.pdf"
+    resume_docx = uploads_dir / "JayResumeDraft.docx"
+    jd_docx = uploads_dir / "JD.docx"
+
+    result = process_uploaded_files([resume_pdf, resume_docx], jd_docx)
+
+    assert "job_description" in result
+    assert isinstance(result["job_description"], str)
+    assert len(result["resumes"]) == 2
+    assert {d["filename"] for d in result["resumes"]} == {resume_pdf.name, resume_docx.name}
+    assert all("text" in d and isinstance(d["text"], str) for d in result["resumes"])  # nosec B101
+
+
+def test_process_uploaded_files_unsupported(tmp_path):
+    with pytest.raises(ValueError):
+        process_uploaded_files(["file.txt"], "JD.docx")

--- a/backend/utils/file_processing.py
+++ b/backend/utils/file_processing.py
@@ -1,0 +1,63 @@
+"""Utilities for processing uploaded resume and job description files."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, List, Dict
+
+from .text_extractor import extract_text_from_pdf, extract_text_from_docx
+
+
+SUPPORTED_EXTENSIONS = {".pdf": extract_text_from_pdf, ".docx": extract_text_from_docx}
+
+
+def _extract_text(file_path: str | Path) -> str:
+    """Extract plain text from a single file based on its extension.
+
+    Parameters
+    ----------
+    file_path: str or Path
+        The path to the file to extract text from. The file extension must be
+        either ``.pdf`` or ``.docx``.
+
+    Returns
+    -------
+    str
+        The extracted plain text.
+
+    Raises
+    ------
+    ValueError
+        If the file extension is unsupported.
+    """
+    path = Path(file_path)
+    extractor = SUPPORTED_EXTENSIONS.get(path.suffix.lower())
+    if extractor is None:
+        raise ValueError(f"Unsupported file type: {path.suffix}")
+    return extractor(path)
+
+
+def process_uploaded_files(resume_paths: List[str | Path], job_description_path: str | Path) -> Dict[str, object]:
+    """Process uploaded resumes and job description into plain text.
+
+    Parameters
+    ----------
+    resume_paths: list of str or Path
+        Paths to resume files. Each file must be a PDF or DOCX.
+    job_description_path: str or Path
+        Path to the job description file (PDF or DOCX).
+
+    Returns
+    -------
+    dict
+        Dictionary containing the job description text under the key
+        ``"job_description"`` and a list of resume dictionaries under ``"resumes"``.
+    """
+    resumes_output: List[Dict[str, str]] = []
+    for path in resume_paths:
+        text = _extract_text(path)
+        resumes_output.append({"filename": Path(path).name, "text": text})
+
+    jd_text = _extract_text(job_description_path)
+
+    return {"job_description": jd_text, "resumes": resumes_output}


### PR DESCRIPTION
## Summary
- add process_uploaded_files to extract text from resumes and job description
- add tests for processing uploaded files

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fitz')*

------
https://chatgpt.com/codex/tasks/task_e_6893dbe7708c8325b18b040d1712c0e5