### PR TITLE
Fix job description upload handling

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -49,7 +49,7 @@ function App() {
         <FileUpload
           label="Select Job Description"
           multiple={false}
-          onFileChange={(file) => setJobDescription(file[0])}
+          onFileChange={setJobDescription}
         />
       </div>
 


### PR DESCRIPTION
## Summary
- fix Select Job Description FileUpload to pass file directly to `setJobDescription`
- submit button remains disabled until resumes and job description are provided

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6893f84ea0788325a3e35c8ec9c08844