### PR TITLE
chore: remove unused Form import

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI, File, UploadFile, Form
+from fastapi import FastAPI, File, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
 import shutil
 from pathlib import Path


### PR DESCRIPTION
## Summary
- remove unused `Form` import from backend main

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fitz')*
- `pip install pymupdf` *(fails: could not find a version due to proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6893fce92e8083258edac68bcd7291a4