### PR TITLE
Process and rank uploaded resumes

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -4,6 +4,9 @@ import shutil
 from pathlib import Path
 from typing import List
 
+from utils.file_processing import process_uploaded_files
+from utils.ranking import rank_resumes_by_similarity
+
 app = FastAPI()
 
 # Allow React frontend to call FastAPI
@@ -37,8 +40,18 @@ async def upload_resumes(
     with open(jd_path, "wb") as buffer:
         shutil.copyfileobj(job_description.file, buffer)
 
+    processed = process_uploaded_files(resume_paths, jd_path)
+    ranked = rank_resumes_by_similarity(
+        processed["resumes"], processed["job_description"]
+    )
+    top_matches = [
+        {"filename": r.get("filename"), "score": r.get("score")}
+        for r in ranked
+    ]
+
     return {
         "message": "Files uploaded successfully",
         "resumes": resume_paths,
-        "job_description": str(jd_path)
+        "job_description": str(jd_path),
+        "top_matches": top_matches,
     }


### PR DESCRIPTION
## Summary
- Process uploaded resumes and job description after saving
- Rank resumes by similarity and return scores in the upload response

## Testing
- `pip install PyMuPDF` *(fails: Could not find a version that satisfies the requirement)*
- `pytest backend/test_file_processing.py::test_process_uploaded_files -q` *(fails: ModuleNotFoundError: No module named 'fitz')*
- `pytest backend/test_ranking.py::test_rank_resumes_by_similarity -q`

------
https://chatgpt.com/codex/tasks/task_e_6893fce68fe08325ad144f0c082e0f8d