### PR TITLE
Ensure ranking results use similarity field

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,8 +1,11 @@
-from fastapi import FastAPI, File, UploadFile, Form
+from fastapi import FastAPI, File, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
 import shutil
 from pathlib import Path
 from typing import List
+
+from utils.file_processing import process_uploaded_files
+from utils.ranking import rank_resumes_by_similarity
 
 app = FastAPI()
 
@@ -37,8 +40,12 @@ async def upload_resumes(
     with open(jd_path, "wb") as buffer:
         shutil.copyfileobj(job_description.file, buffer)
 
+    processed = process_uploaded_files(resume_paths, jd_path)
+    ranked = rank_resumes_by_similarity(
+        processed["resumes"], processed["job_description"]
+    )
+
     return {
         "message": "Files uploaded successfully",
-        "resumes": resume_paths,
-        "job_description": str(jd_path)
+        "top_matches": ranked,
     }

--- a/backend/test_ranking.py
+++ b/backend/test_ranking.py
@@ -34,7 +34,7 @@ def test_rank_resumes_by_similarity():
 
     assert len(ranked) == 2
     assert ranked[0]["filename"] == "A"
-    assert ranked[0]["score"] >= ranked[1]["score"]
+    assert ranked[0]["similarity"] >= ranked[1]["similarity"]
 
 
 def test_rank_resumes_by_similarity_empty_jd():

--- a/backend/utils/ranking.py
+++ b/backend/utils/ranking.py
@@ -40,9 +40,9 @@ def rank_resumes_by_similarity(
     Returns
     -------
     list of dict
-        Each dictionary contains the original resume fields plus a ``score`` key
-        representing the cosine similarity to the job description. The list is
-        sorted in descending order of similarity.
+        Each dictionary contains the original resume fields plus a ``similarity``
+        key representing the cosine similarity to the job description. The list
+        is sorted in descending order of similarity.
     """
     if not job_description:
         return []
@@ -61,14 +61,14 @@ def rank_resumes_by_similarity(
     for resume in resumes:
         embedding = _get_embedding(client, resume.get("text"))
         if embedding is None:
-            score = 0.0
+            similarity = 0.0
         else:
             vector = embedding
             denom = jd_norm * math.sqrt(sum(x * x for x in vector))
-            score = float(
+            similarity = float(
                 sum(a * b for a, b in zip(jd_vector, vector)) / denom
             ) if denom else 0.0
-        ranked.append({**resume, "score": score})
+        ranked.append({**resume, "similarity": similarity})
 
-    ranked.sort(key=lambda x: x["score"], reverse=True)
+    ranked.sort(key=lambda x: x["similarity"], reverse=True)
     return ranked[:top_n]


### PR DESCRIPTION
## Summary
- Standardize resume ranking dictionaries on a `similarity` field
- Return `top_matches` from the upload endpoint using this field

## Testing
- `pytest` *(fails: No module named 'fitz')*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6893fce8706883258889b721052fb5ac