### PR TITLE
Fix top match response

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -45,7 +45,7 @@ async def upload_resumes(
         processed["resumes"], processed["job_description"]
     )
     top_matches = [
-        {"filename": r.get("filename"), "score": r.get("score")}
+        {"filename": r.get("filename"), "similarity": r.get("score")}
         for r in ranked
     ]
 


### PR DESCRIPTION
## Summary
- return ranked resumes via `top_matches` with a `similarity` score

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fitz')*
- `pip install pymupdf` *(fails: Could not find a version that satisfies the requirement pymupdf)*

------
https://chatgpt.com/codex/tasks/task_e_6893fc69bd188325ac67674b78a14a77